### PR TITLE
Add ability to set ownership of created files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,10 @@ None.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
-| required_variable | Describe its purpose. | n/a | Yes |
--->
+| file_owner_group | The name of the group that should own any files or directories created by this role. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
+| file_owner_username | The name of the user that should own any files or directories created by this role. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 
 ## Dependencies ##
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,9 @@
 # tasks file for orchestrator
 - name: Create the /var/cyhy/orchestrator directory
   ansible.builtin.file:
+    group: "{{ file_owner_group | default(omit) }}"
     mode: 0755
+    owner: "{{ file_owner_username | default(omit) }}"
     path: /var/cyhy/orchestrator
     state: directory
 
@@ -11,11 +13,15 @@
     dest: /var/cyhy/orchestrator
     extra_opts:
       - "--strip-components=1"
+    group: "{{ file_owner_group | default(omit) }}"
+    owner: "{{ file_owner_username | default(omit) }}"
     remote_src: yes
     src: https://api.github.com/repos/cisagov/orchestrator/tarball/develop
 
 - name: Create the mount point for the reports volume
   ansible.builtin.file:
+    group: "{{ file_owner_group | default(omit) }}"
     mode: 0755
+    owner: "{{ file_owner_username | default(omit) }}"
     path: /var/cyhy/orchestrator/output
     state: directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,20 +2,20 @@
 # tasks file for orchestrator
 - name: Create the /var/cyhy/orchestrator directory
   ansible.builtin.file:
+    mode: 0755
     path: /var/cyhy/orchestrator
     state: directory
-    mode: 0755
 
 - name: Download and untar the orchestrator tarball
   ansible.builtin.unarchive:
-    src: https://api.github.com/repos/cisagov/orchestrator/tarball/develop
     dest: /var/cyhy/orchestrator
-    remote_src: yes
     extra_opts:
       - "--strip-components=1"
+    remote_src: yes
+    src: https://api.github.com/repos/cisagov/orchestrator/tarball/develop
 
 - name: Create the mount point for the reports volume
   ansible.builtin.file:
+    mode: 0755
     path: /var/cyhy/orchestrator/output
     state: directory
-    mode: 0755


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The primary goal of this pull request is to add two optional variables that can be used to set ownership of any files or directories created by this role. However it also does a bit of alphabetical sorting (to align with our best practices).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Outside of being generally useful this will allow us to set the owner of these files to the `cyhy` user when used in [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis). This is a viable option now that the `cyhy` user is created before this role is called as part of the image building playbook. The rest is just cleanup while we're here.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
