### PR TITLE
Update Molecule test to match new Docker Compose file name

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -27,7 +27,7 @@ def test_directories(host, directory):
         assert oct(host.file(directory["path"]).mode) == directory["mode"]
 
 
-@pytest.mark.parametrize("f", ["/var/cyhy/orchestrator/docker-compose.yml"])
+@pytest.mark.parametrize("f", ["/var/cyhy/orchestrator/compose.yml"])
 def test_command(host, f):
     """Test that appropriate files exist."""
     assert host.file(f).exists


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates a Molecule test to match the new Docker Compose file name.

## 💭 Motivation and context ##

The Docker Compose file name changed in cisagov/orchestrator#165.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.